### PR TITLE
make 1st user as super user

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run -it -p 80:80 -p 3690:3690 --cap-add SYS_PTRACE <image-id>
 
 The default hostname of UOJ is `local_uoj.ac`, so you need to modify your host file in your OS in order to map `127.0.0.1` to `local_uoj.ac`. (It is `/etc/hosts` on Linux.) After that, you can access UOJ in your web browser.
 
-If you need a super user, please register a user and change its `usergroup` to "<samp>S</samp>" in the table `user_info`. Run
+The first user registered after the installation of UOJ will be a super user. If you need another super user, please register a user and change its `usergroup` to "<samp>S</samp>" in the table `user_info`. Run
 ```sh
 mysql app_uoj233 -u root -p
 ```

--- a/uoj/1/app/controllers/register.php
+++ b/uoj/1/app/controllers/register.php
@@ -34,7 +34,10 @@
 		$esc_email = DB::escape($email);
 		
 		$svn_pw = uojRandString(10);
-	mysql_query("insert into user_info (username, email, password, svn_password, register_time) values ('$username', '$esc_email', '$password', '$svn_pw', now())");
+		if (!DB::selectCount("SELECT COUNT(*) FROM user_info"))
+			mysql_query("insert into user_info (username, email, password, svn_password, register_time, usergroup) values ('$username', '$esc_email', '$password', '$svn_pw', now(), 'S')");
+		else
+			mysql_query("insert into user_info (username, email, password, svn_password, register_time) values ('$username', '$esc_email', '$password', '$svn_pw', now())");
 		
 		return "欢迎你！" . $username . "，你已成功注册。";
 	}


### PR DESCRIPTION
Automatically make the 1st user registered as a super user after the installation of UOJ. This eases the management.