### PR TITLE
Suggest users to use --cap-add SYS_PTRACE all the time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,9 @@ If everything goes well, you will see `Successfully built <image-id>` in the las
 
 To start your UOJ main server, please run:
 ```sh
-docker run -it -p 80:80 -p 3690:3690 <image-id>
-```
-If you are using docker on Mac OS or having 'std: compile error. no comment' message on uploading problem data, you could possibly use this alternative command:
-```sh
 docker run -it -p 80:80 -p 3690:3690 --cap-add SYS_PTRACE <image-id>
 ```
+If you are encountering 'std: compile error. no comment' message when uploading problem data, please refer to [here](https://vfleaking.github.io/uoj/install/).
 
 The default hostname of UOJ is `local_uoj.ac`, so you need to modify your host file in your OS in order to map `127.0.0.1` to `local_uoj.ac`. (It is `/etc/hosts` on Linux.) After that, you can access UOJ in your web browser.
 

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -12,9 +12,7 @@
 
 关于如何传题请参见[题目文档](problem/)
 
-啊如果你在 “与svn仓库同步” 的过程中发现 <samp>compile error</samp> 并且还说 <samp>no comment</samp> 的话……多半是……UOJ 尝试 ptrace 然而 ptrace 被禁了……
-
-被禁了可能是被 docker 禁了，可以加一句 `--cap-add SYS_PTRACE` （见 [README.md](https://github.com/vfleaking/uoj/blob/master/README.md)）……要是这样不能解决问题……是 Ubuntu/openSUSE 环境嘛？请尝试用下面的命令阻止 AppArmor 对 docker 的行为产生影响。当然把第二行加到 `rc.local` 里就不用每次重启都输入一遍啦~（详细解释戳 [→ 这里](https://github.com/docker/docker/issues/7276)）
+啊如果你在 “与svn仓库同步” 的过程中发现 <samp>compile error</samp> 并且还说 <samp>no comment</samp> 的话……多半是……UOJ 尝试 ptrace 然而 ptrace 被禁了。如果是 Ubuntu/openSUSE 环境，请尝试用下面的命令阻止 AppArmor 对 docker 的行为产生影响。把第二行加到 `rc.local` 里就不用每次重启都输入一遍了。（详细解释请见 [这里](https://github.com/docker/docker/issues/7276)）
 
 ```sh
 sudo apt-get install apparmor-utils


### PR DESCRIPTION
`--cap-add SYS_PTRACE`选项似乎没什么坏处，而且不加一般都是有问题的，不如默认就让用户加上。