### PR TITLE
修改了每个线程的堆栈大小

### DIFF
--- a/judge_client/1/uoj_judger/run/run_program.cpp
+++ b/judge_client/1/uoj_judger/run/run_program.cpp
@@ -208,10 +208,10 @@ void parse_args(int argc, char **argv) {
 		string pre[3] = {"/usr/bin/python3.4", "-I", "-B"};
 		run_program_config.argv.insert(run_program_config.argv.begin(), pre, pre + 3);
 	} else if (run_program_config.type == "java7u76") {
-		string pre[3] = {abspath(0, string(self_path) + "/../runtime/jdk1.7.0_76/bin/java"), "-Xmx1024m", "-Xss1024m"};
+		string pre[3] = {abspath(0, string(self_path) + "/../runtime/jdk1.7.0_76/bin/java"), "-Xmx1024m", "-Xss256m"};
 		run_program_config.argv.insert(run_program_config.argv.begin(), pre, pre + 3);
 	} else if (run_program_config.type == "java8u31") {
-		string pre[3] = {abspath(0, string(self_path) + "/../runtime/jdk1.8.0_31/bin/java"), "-Xmx1024m", "-Xss1024m"};
+		string pre[3] = {abspath(0, string(self_path) + "/../runtime/jdk1.8.0_31/bin/java"), "-Xmx1024m", "-Xss256m"};
 		run_program_config.argv.insert(run_program_config.argv.begin(), pre, pre + 3);
 	}
 }


### PR DESCRIPTION
如果线程堆栈大小与jvm虚拟机被分配的大小一样，很容易出现内存溢出的问题。