### PR TITLE
防止表单多次提交

### DIFF
--- a/web/app/controllers/problem.php
+++ b/web/app/controllers/problem.php
@@ -118,6 +118,7 @@ if ($custom_test_enabled) {
 		return '';
 	};
 	$custom_test_form->ctrl_enter_submit = true;
+	$custom_test_form->prevent_multiple_submit = false;
 	$custom_test_form->setAjaxSubmit(<<<EOD
 		function(response_text) {
 			custom_test_onsubmit(

--- a/web/app/uoj-form-lib.php
+++ b/web/app/uoj-form-lib.php
@@ -533,6 +533,12 @@ class UOJForm {
 					EOD;
 		} else {
 			echo <<<EOD
+							if (ok) {
+								$("#button-submit-{$this->form_name}").addClass('disabled');
+								$(this).submit(function () {
+									return false;
+								});
+							}
 							return ok;
 
 					EOD;

--- a/web/app/uoj-form-lib.php
+++ b/web/app/uoj-form-lib.php
@@ -10,6 +10,7 @@ class UOJForm {
 	public $is_big = false;
 	public $has_file = false;
 	public $ajax_submit_js = null;
+	public $prevent_multiple_submit = true;
 	public $run_at_server_handler = array();
 	private $data = array();
 	private $vdata = array();
@@ -518,6 +519,18 @@ class UOJForm {
 					EOD;
 		}
 
+		
+		if ($this->prevent_multiple_submit) {
+			echo <<<EOD
+							if (ok) {
+								$("#button-submit-{$this->form_name}").addClass('disabled');
+								$(this).submit(function () {
+									return false;
+								});
+							}
+
+					EOD;
+		}
 		if ($this->ajax_submit_js !== null) {
 			echo <<<EOD
 							e.preventDefault();
@@ -533,12 +546,6 @@ class UOJForm {
 					EOD;
 		} else {
 			echo <<<EOD
-							if (ok) {
-								$("#button-submit-{$this->form_name}").addClass('disabled');
-								$(this).submit(function () {
-									return false;
-								});
-							}
 							return ok;
 
 					EOD;


### PR DESCRIPTION
在网络状况不佳的情况下，提交表单时页面可能会卡住不动，此时如果再次点击「提交」按钮就会重复发送请求。这会导致一些无用的提交记录、评论等内容产生，因此应该在表单首次提交后将提交按钮禁用，并修改表单验证函数以阻止后续提交。

以目前来看，UOJ 暂时没有在服务器端防止表单重复提交的需求，因此本 PR 并不涉及相关内容。