### PR TITLE
修正上传 zip 数据文件时子目录名包含空格导致的命令运行失败

### DIFF
--- a/web/app/uoj-svn-lib.php
+++ b/web/app/uoj-svn-lib.php
@@ -247,9 +247,9 @@ class SvnProblemDataManager {
 			UOJLocalRun::execAnd([
 				['cd', $this->upload_dir],
 				<<<'EOD'
-				if [ `find . -maxdepth 1 -type f`File = File ];
-				then for sub_dir in `find -maxdepth 1 -type d ! -name .`;
-				do mv -f $sub_dir/* . && rm -rf $sub_dir; done; fi
+				if [ "$(find . -maxdepth 1 -type f)File" = "File" ];
+				then for sub_dir in "$(find -maxdepth 1 -type d ! -name .)";
+				do mv -f "$sub_dir"/* . && rm -rf "$sub_dir"; done; fi
 				EOD
 			]);
 			


### PR DESCRIPTION
相关 commit：https://github.com/renbaoshuo/S2OJ/commit/e6e7e77e8ec8058260874df5408c638165cb872f